### PR TITLE
FIX: Account Manager creates Accounts with undefined keys

### DIFF
--- a/core/eosio_wrappers/account/EOSIOAccountManager.js
+++ b/core/eosio_wrappers/account/EOSIOAccountManager.js
@@ -25,8 +25,8 @@ class EOSIOAccountManager {
             let activePublicKey = PrivateKey.fromString(activePrivateKey).toPublic().toString();
             await EOSIONode.importKey(infeos_config.wallet, activePrivateKey, 'yes');
             
-            let ownerKeys = {"PUBLIC_KEY": ownerPublicKey, "PRIVATE_KEY": ownerPrivateKey};
-            let activeKeys = {"PUBLIC_KEY": activePublicKey, "PRIVATE_KEY": activePrivateKey};
+            let ownerKeys = {publicKey: ownerPublicKey, privateKey: ownerPrivateKey};
+            let activeKeys = {publicKey: activePublicKey, privateKey: activePrivateKey};
 
             let accountName = generateAccountName();
 


### PR DESCRIPTION
Fix: EOSIOAccountManager uses UPPER_CASE for key dictionaries, so the keys end up to be `undefined` in the EOSIOAccount as the constructor refers to them as `publicKey` and `privateKey`